### PR TITLE
bug fix:Change context entity to GoodslocationEntity

### DIFF
--- a/backend/ModernWMS.WMS/Services/Stock/StockService.cs
+++ b/backend/ModernWMS.WMS/Services/Stock/StockService.cs
@@ -687,7 +687,7 @@ namespace ModernWMS.WMS.Services
             var dispatchpick_DBSet = _dBContext.GetDbSet<DispatchpicklistEntity>();
             var sku_DBSet = _dBContext.GetDbSet<SkuEntity>();
             var spu_DBSet = _dBContext.GetDbSet<SpuEntity>();
-            var location_DBSet = _dBContext.GetDbSet<WarehouseareaEntity>();
+            var location_DBSet = _dBContext.GetDbSet<GoodslocationEntity>();
             var warehouse_DBSet = _dBContext.GetDbSet<WarehouseEntity>();
             var owner_DbSet = _dBContext.GetDbSet<GoodsownerEntity>();
             if (input.delivery_date_from > UtilConvert.MinDate)
@@ -713,7 +713,7 @@ namespace ModernWMS.WMS.Services
                         {
                             dp.dispatch_no,
                             wh.warehouse_name,
-                            location_name = location.area_name,
+                            location.location_name,
                             spu.spu_name,
                             spu.spu_code,
                             sku.sku_name,


### PR DESCRIPTION
Shipment statistics table linq sql cannot get result data.
Seems like the GoodslocationEntity join is wrong.
I changed the Context entity from WarehouseareaEntity to GoodslocationEntity and its looks like OK.

发货统计页面无法检索出数据。
这里连接实体可能搞错了？我从WarehouseareaEntity 修改成 GoodslocationEntity 正常检索出出库数据。
不是对这个系统的业务很熟悉。
请Review一下这里的业务。